### PR TITLE
Fix import for AjusteStock mutations

### DIFF
--- a/centrex-graphql/backend/app/mutations/ajustes_stock.py
+++ b/centrex-graphql/backend/app/mutations/ajustes_stock.py
@@ -28,3 +28,11 @@ class AjusteStockMutations:
         result = delete_ajuste_stock(db, id_ajuste_stock)
         db.close()
         return result
+
+# Alias for backward compatibility with old imports
+AjustesStockMutations = AjusteStockMutations
+
+__all__ = [
+    "AjusteStockMutations",
+    "AjustesStockMutations",
+]


### PR DESCRIPTION
## Summary
- allow importing `AjustesStockMutations` for backward compatibility
- export alias via `__all__`

## Testing
- `python3 -m py_compile centrex-graphql/backend/app/mutations/ajustes_stock.py`
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879bced4bb48323a409afac8dd6dd7a