### PR TITLE
Add basic React frontend and login mutation

### DIFF
--- a/centrex-graphql/backend/app/auth.py
+++ b/centrex-graphql/backend/app/auth.py
@@ -10,11 +10,13 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-def verify_password(plain_password, hashed_password):
-    return pwd_context.verify(plain_password, hashed_password)
+def verify_password(plain_password: str, stored_password: str) -> bool:
+    """Verify password equality (plaintext for now)."""
+    return plain_password == stored_password
 
-def get_password_hash(password):
-    return pwd_context.hash(password)
+def get_password_hash(password: str) -> str:
+    """Return the password as-is because we store plaintext for now."""
+    return password
 
 def create_access_token(data: dict):
     to_encode = data.copy()
@@ -23,9 +25,11 @@ def create_access_token(data: dict):
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
 def authenticate_user(db: Session, username: str, password: str):
-    user = db.query(Usuario).filter(Usuario.username == username).first()
+    """Authenticate a user with plaintext password."""
+    user = db.query(Usuario).filter(Usuario.usuario == username).first()
     if not user:
         return None
     if not verify_password(password, user.password):
         return None
     return user
+

--- a/centrex-graphql/backend/app/crud/usuarios.py
+++ b/centrex-graphql/backend/app/crud/usuarios.py
@@ -24,3 +24,7 @@ def update_usuario(db: Session, db_obj, updates):
 def delete_usuario(db: Session, db_obj):
     db.delete(db_obj)
     db.commit()
+
+def get_usuario_by_username(db: Session, username: str):
+    """Return a single Usuario by its username."""
+    return db.query(Usuario).filter(Usuario.usuario == username).first()

--- a/centrex-graphql/backend/app/mutations/usuarios.py
+++ b/centrex-graphql/backend/app/mutations/usuarios.py
@@ -2,7 +2,13 @@ import strawberry
 from typing import Optional
 from app.schemas.usuarios import UsuarioType, UsuarioInput
 from app.db import SessionLocal
-from app.crud.usuarios import create_usuario, update_usuario, delete_usuario, get_usuarios_by_id
+from app.crud.usuarios import (
+    create_usuario,
+    update_usuario,
+    delete_usuario,
+    get_usuarios_by_id,
+)
+from app.auth import authenticate_user, create_access_token
 
 @strawberry.type
 class UsuarioMutations:
@@ -34,3 +40,16 @@ class UsuarioMutations:
         delete_usuario(db, db_obj)                     # <--- Pasar el objeto
         db.close()
         return True
+
+    @strawberry.mutation
+    def login(self, username: str, password: str) -> Optional[str]:
+        """Authenticate user and return an access token."""
+        db = SessionLocal()
+        user = authenticate_user(db, username, password)
+        if not user:
+            db.close()
+            return None
+        token = create_access_token({"sub": user.usuario})
+        db.close()
+        return token
+

--- a/centrex-graphql/frontend/index.html
+++ b/centrex-graphql/frontend/index.html
@@ -1,0 +1,13 @@
+<!-- centrex-graphql/frontend/index.html -->
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Centrex ERP</title>
+    <script type="module" src="/src/main.tsx"></script>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+  </body>
+</html>

--- a/centrex-graphql/frontend/package.json
+++ b/centrex-graphql/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "centrex-frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.1.0",
+    "typescript": "^5.2.0",
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/centrex-graphql/frontend/postcss.config.js
+++ b/centrex-graphql/frontend/postcss.config.js
@@ -1,0 +1,7 @@
+// centrex-graphql/frontend/postcss.config.js
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/centrex-graphql/frontend/src/App.tsx
+++ b/centrex-graphql/frontend/src/App.tsx
@@ -1,0 +1,17 @@
+// centrex-graphql/frontend/src/App.tsx
+import React, { useState, useEffect } from 'react';
+import Login from './pages/Login';
+import Dashboard from './pages/Dashboard';
+import { getToken } from './utils/auth';
+
+const App: React.FC = () => {
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    setToken(getToken());
+  }, []);
+
+  return token ? <Dashboard onLogout={() => setToken(null)} /> : <Login onLogin={setToken} />;
+};
+
+export default App;

--- a/centrex-graphql/frontend/src/components/Header.tsx
+++ b/centrex-graphql/frontend/src/components/Header.tsx
@@ -1,0 +1,17 @@
+// centrex-graphql/frontend/src/components/Header.tsx
+import React from 'react';
+
+interface Props {
+  onLogout: () => void;
+}
+
+const Header: React.FC<Props> = ({ onLogout }) => (
+  <header className="bg-blue-600 text-white p-4 flex justify-between">
+    <h1 className="font-bold">Centrex ERP</h1>
+    <button onClick={onLogout} className="underline">
+      Cerrar sesión
+    </button>
+  </header>
+);
+
+export default Header;

--- a/centrex-graphql/frontend/src/components/Sidebar.tsx
+++ b/centrex-graphql/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,15 @@
+// centrex-graphql/frontend/src/components/Sidebar.tsx
+import React from 'react';
+import entities from '../data/entities';
+
+const Sidebar: React.FC = () => (
+  <aside className="w-60 bg-gray-800 text-white p-4 space-y-2 overflow-y-auto">
+    {entities.map((e) => (
+      <div key={e} className="hover:bg-gray-700 p-2 rounded">
+        {e}
+      </div>
+    ))}
+  </aside>
+);
+
+export default Sidebar;

--- a/centrex-graphql/frontend/src/data/entities.ts
+++ b/centrex-graphql/frontend/src/data/entities.ts
@@ -1,0 +1,12 @@
+// centrex-graphql/frontend/src/data/entities.ts
+const entities = [
+  'usuarios',
+  'clientes',
+  'proveedores',
+  'items',
+  'pedidos',
+  'pagos',
+  'empresa',
+];
+
+export default entities;

--- a/centrex-graphql/frontend/src/index.css
+++ b/centrex-graphql/frontend/src/index.css
@@ -1,0 +1,4 @@
+/* centrex-graphql/frontend/src/index.css */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/centrex-graphql/frontend/src/main.tsx
+++ b/centrex-graphql/frontend/src/main.tsx
@@ -1,0 +1,11 @@
+// centrex-graphql/frontend/src/main.tsx
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/centrex-graphql/frontend/src/pages/Dashboard.tsx
+++ b/centrex-graphql/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,28 @@
+// centrex-graphql/frontend/src/pages/Dashboard.tsx
+import React from 'react';
+import Header from '../components/Header';
+import Sidebar from '../components/Sidebar';
+import { clearToken } from '../utils/auth';
+
+interface Props {
+  onLogout: () => void;
+}
+
+const Dashboard: React.FC<Props> = ({ onLogout }) => {
+  const handleLogout = () => {
+    clearToken();
+    onLogout();
+  };
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar />
+      <div className="flex-1 flex flex-col">
+        <Header onLogout={handleLogout} />
+        <main className="p-4">Bienvenido al dashboard</main>
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/centrex-graphql/frontend/src/pages/Login.tsx
+++ b/centrex-graphql/frontend/src/pages/Login.tsx
@@ -1,0 +1,51 @@
+// centrex-graphql/frontend/src/pages/Login.tsx
+import React, { useState } from 'react';
+import { login } from '../utils/auth';
+
+interface Props {
+  onLogin: (token: string) => void;
+}
+
+const Login: React.FC<Props> = ({ onLogin }) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const token = await login(username, password);
+    if (token) {
+      onLogin(token);
+    } else {
+      setError('Credenciales inválidas');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-200">
+      <form onSubmit={handleSubmit} className="bg-white p-8 rounded shadow w-80">
+        <h1 className="text-xl mb-4 text-center">Centrex ERP</h1>
+        {error && <p className="text-red-500 mb-2">{error}</p>}
+        <input
+          type="text"
+          placeholder="Usuario"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="border p-2 w-full mb-2"
+        />
+        <input
+          type="password"
+          placeholder="Contraseña"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2 w-full mb-4"
+        />
+        <button type="submit" className="bg-blue-600 text-white py-2 px-4 w-full">
+          Ingresar
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/centrex-graphql/frontend/src/utils/auth.ts
+++ b/centrex-graphql/frontend/src/utils/auth.ts
@@ -1,0 +1,25 @@
+// centrex-graphql/frontend/src/utils/auth.ts
+const TOKEN_KEY = 'centrex_token';
+
+export async function login(username: string, password: string): Promise<string | null> {
+  const query = `mutation Login($username: String!, $password: String!) {\n  login(username: $username, password: $password)\n}`;
+  const res = await fetch('http://localhost:8000/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables: { username, password } }),
+  });
+  const json = await res.json();
+  const token = json.data?.login as string | null;
+  if (token) {
+    localStorage.setItem(TOKEN_KEY, token);
+  }
+  return token;
+}
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function clearToken() {
+  localStorage.removeItem(TOKEN_KEY);
+}

--- a/centrex-graphql/frontend/tailwind.config.js
+++ b/centrex-graphql/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+// centrex-graphql/frontend/tailwind.config.js
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/centrex-graphql/frontend/tsconfig.json
+++ b/centrex-graphql/frontend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/centrex-graphql/frontend/vite.config.ts
+++ b/centrex-graphql/frontend/vite.config.ts
@@ -1,0 +1,7 @@
+// centrex-graphql/frontend/vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- implement login mutation and plaintext auth
- add helper to fetch user by username
- bootstrap Vite + React + Tailwind frontend
- create basic login form, dashboard, header and sidebar

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879c37c88648323b8c215e0138e154c