### PR TITLE
Fix missing DB tables in startup

### DIFF
--- a/centrex-graphql/backend/app/__init__.py
+++ b/centrex-graphql/backend/app/__init__.py
@@ -4,6 +4,7 @@ from . import crud
 from . import mutations
 from . import resolvers
 from . import schemas
+from .db import Base, engine
 
 __all__ = [
     "models",
@@ -12,3 +13,6 @@ __all__ = [
     "resolvers",
     "schemas",
 ]
+
+# Ensure database tables are created when the application starts
+Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- ensure DB tables are created when the backend starts

## Testing
- `python3 -m compileall app`

------
https://chatgpt.com/codex/tasks/task_e_6879cae1ba408323a05c8fbc4a188a47