### PR TITLE
Fix missing DB tables in startup

### DIFF
--- a/centrex-graphql/backend/app/__init__.py
+++ b/centrex-graphql/backend/app/__init__.py
@@ -4,6 +4,7 @@ from . import crud
 from . import mutations
 from . import resolvers
 from . import schemas
+from .db import Base, engine
 
 __all__ = [
     "models",
@@ -12,3 +13,6 @@ __all__ = [
     "resolvers",
     "schemas",
 ]
+
+# Ensure database tables are created when the application starts
+Base.metadata.create_all(bind=engine)

--- a/centrex-graphql/backend/app/db.py
+++ b/centrex-graphql/backend/app/db.py
@@ -3,10 +3,11 @@ from sqlalchemy.orm import sessionmaker, declarative_base
 import os
 
 # Datos de conexión a la base de datos. Se puede configurar con la variable
-# de entorno DATABASE_URL. Por defecto se usa SQLite para facilitar el inicio.
+# de entorno DATABASE_URL. De forma predeterminada se conecta a SQL Server
+# en 127.0.0.1 utilizando las credenciales proporcionadas.
 SQLALCHEMY_DATABASE_URL = os.getenv(
     "DATABASE_URL",
-    "sqlite:///./development.db",
+    "mssql+pyodbc://sa:Ladeda78@127.0.0.1/dbCentrex?driver=ODBC+Driver+17+for+SQL+Server",
 )
 
 engine_kwargs = {"echo": True}


### PR DESCRIPTION
## Summary
- ensure DB tables are created when the backend starts
- default DB config now targets local SQL Server

## Testing
- `python3 -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_e_6879cae1ba408323a05c8fbc4a188a47