### PR TITLE
Add SQLAlchemy echo toggle

### DIFF
--- a/centrex-graphql/README.md
+++ b/centrex-graphql/README.md
@@ -1,0 +1,15 @@
+# centrex-graphql/README.md
+
+## Configuración de logs de SQLAlchemy
+
+Para evitar que se impriman todas las consultas SQL al iniciar el backend,
+se añadió la variable de entorno `SQLALCHEMY_ECHO`. Por defecto está
+inactiva, por lo que los logs dejarán de mostrarse.
+
+Si necesitas habilitar la salida detallada de SQLAlchemy, define:
+
+```bash
+export SQLALCHEMY_ECHO=true
+```
+
+antes de ejecutar el servidor.

--- a/centrex-graphql/backend/app/db.py
+++ b/centrex-graphql/backend/app/db.py
@@ -10,7 +10,9 @@ SQLALCHEMY_DATABASE_URL = os.getenv(
     "mssql+pyodbc://sa:Ladeda78@127.0.0.1/dbCentrex?driver=ODBC+Driver+17+for+SQL+Server",
 )
 
-engine_kwargs = {"echo": True}
+engine_kwargs = {
+    "echo": os.getenv("SQLALCHEMY_ECHO", "false").lower() == "true"
+}
 if SQLALCHEMY_DATABASE_URL.startswith("mssql+pyodbc"):
     engine_kwargs["fast_executemany"] = True
 


### PR DESCRIPTION
## Summary
- allow disabling SQLAlchemy query logging via the `SQLALCHEMY_ECHO` environment variable
- document the new variable in `centrex-graphql/README.md`

## Testing
- `python -m py_compile centrex-graphql/backend/app/db.py`


------
https://chatgpt.com/codex/tasks/task_e_6879d79d66d88323b0f764c4915619a9