### PR TITLE
Fix CRUD lookups and decimal casting

### DIFF
--- a/centrex-graphql/backend/app/crud/tmpcobros_retenciones.py
+++ b/centrex-graphql/backend/app/crud/tmpcobros_retenciones.py
@@ -7,6 +7,10 @@ def get_all_tmpcobros_retenciones(db: Session):
 def get_tmpcobros_retenciones_by_id(db: Session, id: int):
     return db.query(TmpCobroRetencion).filter(TmpCobroRetencion.id_tmpCobroRetencion == id).first()
 
+def get_tmpcobro_retencion_by_id(db: Session, id: int):
+    """Return a single TmpCobroRetencion by its primary key."""
+    return db.query(TmpCobroRetencion).filter(TmpCobroRetencion.id_tmpCobroRetencion == id).first()
+
 def create_tmpcobro_retencion(db: Session, obj):
     db_obj = TmpCobroRetencion(**obj.dict())
     db.add(db_obj)

--- a/centrex-graphql/backend/app/crud/tmpproduccion_items.py
+++ b/centrex-graphql/backend/app/crud/tmpproduccion_items.py
@@ -7,6 +7,10 @@ def get_all_tmpproduccion_items(db: Session):
 def get_tmpproduccion_items_by_id(db: Session, id: int):
     return db.query(TmpProduccionItem).filter(TmpProduccionItem.id_tmpProduccionItem == id).first()
 
+def get_tmpproduccion_item_by_id(db: Session, id: int):
+    """Return a single TmpProduccionItem by its primary key."""
+    return db.query(TmpProduccionItem).filter(TmpProduccionItem.id_tmpProduccionItem == id).first()
+
 def create_tmpproduccion_item(db: Session, obj):
     db_obj = TmpProduccionItem(**obj.dict())
     db.add(db_obj)

--- a/centrex-graphql/backend/app/resolvers/comprobantes_compras.py
+++ b/centrex-graphql/backend/app/resolvers/comprobantes_compras.py
@@ -1,5 +1,6 @@
 import strawberry
-from typing import List, Optional
+from typing import List, Optional, cast
+from decimal import Decimal
 from app.schemas.comprobantes_compras import ComprobanteCompraType
 from app.db import SessionLocal
 from app.crud.comprobantes_compras import get_comprobante_compra, get_comprobantes_compras
@@ -18,7 +19,7 @@ class ComprobanteCompraQueries:
                 fecha=c.fecha,
                 tipo_comprobante=c.tipo_comprobante,
                 numero=c.numero,
-                total=float(c.total),
+                total=float(cast(Decimal, c.total)),
                 estado=c.estado,
                 observaciones=c.observaciones
             ) for c in result
@@ -37,7 +38,7 @@ class ComprobanteCompraQueries:
             fecha=c.fecha,
             tipo_comprobante=c.tipo_comprobante,
             numero=c.numero,
-            total=float(c.total),
+            total=float(cast(Decimal, c.total)),
             estado=c.estado,
             observaciones=c.observaciones
         )

--- a/centrex-graphql/backend/app/resolvers/comprobantes_compras_conceptos.py
+++ b/centrex-graphql/backend/app/resolvers/comprobantes_compras_conceptos.py
@@ -1,5 +1,6 @@
 import strawberry
-from typing import List, Optional
+from typing import List, Optional, cast
+from decimal import Decimal
 from app.schemas.comprobantes_compras_conceptos import ComprobanteCompraConceptoType
 from app.db import SessionLocal
 from app.crud.comprobantes_compras_conceptos import get_comprobante_compra_concepto, get_comprobantes_compras_conceptos
@@ -16,7 +17,7 @@ class ComprobanteCompraConceptoQueries:
                 id_concepto=c.id_concepto,
                 id_comprobante_compra=c.id_comprobante_compra,
                 descripcion=c.descripcion,
-                importe=float(c.importe)
+                importe=float(cast(Decimal, c.importe))
             ) for c in result
         ]
 
@@ -31,5 +32,5 @@ class ComprobanteCompraConceptoQueries:
             id_concepto=c.id_concepto,
             id_comprobante_compra=c.id_comprobante_compra,
             descripcion=c.descripcion,
-            importe=float(c.importe)
+            importe=float(cast(Decimal, c.importe))
         )

--- a/centrex-graphql/backend/app/resolvers/comprobantes_compras_impuestos.py
+++ b/centrex-graphql/backend/app/resolvers/comprobantes_compras_impuestos.py
@@ -1,5 +1,6 @@
 import strawberry
-from typing import List, Optional
+from typing import List, Optional, cast
+from decimal import Decimal
 from app.schemas.comprobantes_compras_impuestos import ComprobanteCompraImpuestoType
 from app.db import SessionLocal
 from app.crud.comprobantes_compras_impuestos import get_comprobante_compra_impuesto, get_comprobantes_compras_impuestos
@@ -16,7 +17,7 @@ class ComprobanteCompraImpuestoQueries:
                 id_impuesto=c.id_impuesto,
                 id_comprobante_compra=c.id_comprobante_compra,
                 tipo_impuesto=c.tipo_impuesto,
-                importe=float(c.importe)
+                importe=float(cast(Decimal, c.importe))
             ) for c in result
         ]
 
@@ -31,5 +32,5 @@ class ComprobanteCompraImpuestoQueries:
             id_impuesto=c.id_impuesto,
             id_comprobante_compra=c.id_comprobante_compra,
             tipo_impuesto=c.tipo_impuesto,
-            importe=float(c.importe)
+            importe=float(cast(Decimal, c.importe))
         )

--- a/centrex-graphql/backend/app/resolvers/comprobantes_compras_items.py
+++ b/centrex-graphql/backend/app/resolvers/comprobantes_compras_items.py
@@ -1,5 +1,6 @@
 import strawberry
-from typing import List, Optional
+from typing import List, Optional, cast
+from decimal import Decimal
 from app.schemas.comprobantes_compras_items import ComprobanteCompraItemType
 from app.db import SessionLocal
 from app.crud.comprobantes_compras_items import get_comprobante_compra_item, get_comprobantes_compras_items
@@ -16,9 +17,9 @@ class ComprobanteCompraItemQueries:
                 id_item=c.id_item,
                 id_comprobante_compra=c.id_comprobante_compra,
                 descripcion=c.descripcion,
-                cantidad=float(c.cantidad),
-                precio_unitario=float(c.precio_unitario),
-                subtotal=float(c.subtotal)
+                cantidad=float(cast(Decimal, c.cantidad)),
+                precio_unitario=float(cast(Decimal, c.precio_unitario)),
+                subtotal=float(cast(Decimal, c.subtotal))
             ) for c in result
         ]
 
@@ -33,7 +34,7 @@ class ComprobanteCompraItemQueries:
             id_item=c.id_item,
             id_comprobante_compra=c.id_comprobante_compra,
             descripcion=c.descripcion,
-            cantidad=float(c.cantidad),
-            precio_unitario=float(c.precio_unitario),
-            subtotal=float(c.subtotal)
+            cantidad=float(cast(Decimal, c.cantidad)),
+            precio_unitario=float(cast(Decimal, c.precio_unitario)),
+            subtotal=float(cast(Decimal, c.subtotal))
         )


### PR DESCRIPTION
## Summary
- implement missing `get_tmpcobro_retencion_by_id` and `get_tmpproduccion_item_by_id`
- cast decimals properly in various comprobantes resolvers

## Testing
- `python -m py_compile centrex-graphql/backend/app/resolvers/comprobantes_compras.py`
- `python -m py_compile centrex-graphql/backend/app/resolvers/comprobantes_compras_conceptos.py`
- `python -m py_compile centrex-graphql/backend/app/resolvers/comprobantes_compras_impuestos.py`
- `python -m py_compile centrex-graphql/backend/app/resolvers/comprobantes_compras_items.py`
- `python -m py_compile centrex-graphql/backend/app/crud/tmpcobros_retenciones.py`
- `python -m py_compile centrex-graphql/backend/app/crud/tmpproduccion_items.py`
- `python -m py_compile centrex-graphql/backend/app/mutations/tmpcobros_retenciones.py`
- `python -m py_compile centrex-graphql/backend/app/mutations/tmpproduccion_items.py`


------
https://chatgpt.com/codex/tasks/task_e_6879df18c4848323b301aa83a76a5538